### PR TITLE
Add bytecode serialization to Bhasa compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ bhasa
 *.so
 *.dylib
 
+# Compiled bytecode files
+*.compiled
+*.সংকলিত
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/compiler/serializer.go
+++ b/compiler/serializer.go
@@ -1,0 +1,427 @@
+package compiler
+
+import (
+	"bhasa/code"
+	"bhasa/object"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Magic number for Bhasa bytecode files: "BHASA" in hex
+const (
+	MagicNumber uint32 = 0x42484153 // "BHAS"
+	Version     uint32 = 1
+)
+
+// Serialize writes the bytecode to a writer in binary format
+func (b *Bytecode) Serialize(w io.Writer) error {
+	// Write magic number
+	if err := binary.Write(w, binary.BigEndian, MagicNumber); err != nil {
+		return fmt.Errorf("failed to write magic number: %w", err)
+	}
+
+	// Write version
+	if err := binary.Write(w, binary.BigEndian, Version); err != nil {
+		return fmt.Errorf("failed to write version: %w", err)
+	}
+
+	// Write instructions length
+	instructionsLen := uint32(len(b.Instructions))
+	if err := binary.Write(w, binary.BigEndian, instructionsLen); err != nil {
+		return fmt.Errorf("failed to write instructions length: %w", err)
+	}
+
+	// Write instructions
+	if _, err := w.Write(b.Instructions); err != nil {
+		return fmt.Errorf("failed to write instructions: %w", err)
+	}
+
+	// Write constants count
+	constantsCount := uint32(len(b.Constants))
+	if err := binary.Write(w, binary.BigEndian, constantsCount); err != nil {
+		return fmt.Errorf("failed to write constants count: %w", err)
+	}
+
+	// Write each constant
+	for i, constant := range b.Constants {
+		if err := serializeObject(w, constant); err != nil {
+			return fmt.Errorf("failed to serialize constant %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// Deserialize reads bytecode from a reader
+func Deserialize(r io.Reader) (*Bytecode, error) {
+	// Read and verify magic number
+	var magic uint32
+	if err := binary.Read(r, binary.BigEndian, &magic); err != nil {
+		return nil, fmt.Errorf("failed to read magic number: %w", err)
+	}
+	if magic != MagicNumber {
+		return nil, fmt.Errorf("invalid magic number: expected 0x%X, got 0x%X", MagicNumber, magic)
+	}
+
+	// Read and verify version
+	var version uint32
+	if err := binary.Read(r, binary.BigEndian, &version); err != nil {
+		return nil, fmt.Errorf("failed to read version: %w", err)
+	}
+	if version != Version {
+		return nil, fmt.Errorf("unsupported bytecode version: expected %d, got %d", Version, version)
+	}
+
+	// Read instructions length
+	var instructionsLen uint32
+	if err := binary.Read(r, binary.BigEndian, &instructionsLen); err != nil {
+		return nil, fmt.Errorf("failed to read instructions length: %w", err)
+	}
+
+	// Read instructions
+	instructions := make(code.Instructions, instructionsLen)
+	if _, err := io.ReadFull(r, instructions); err != nil {
+		return nil, fmt.Errorf("failed to read instructions: %w", err)
+	}
+
+	// Read constants count
+	var constantsCount uint32
+	if err := binary.Read(r, binary.BigEndian, &constantsCount); err != nil {
+		return nil, fmt.Errorf("failed to read constants count: %w", err)
+	}
+
+	// Read each constant
+	constants := make([]object.Object, constantsCount)
+	for i := uint32(0); i < constantsCount; i++ {
+		constant, err := deserializeObject(r)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize constant %d: %w", i, err)
+		}
+		constants[i] = constant
+	}
+
+	return &Bytecode{
+		Instructions: instructions,
+		Constants:    constants,
+	}, nil
+}
+
+// Object type identifiers for serialization
+const (
+	objTypeInteger         byte = 1
+	objTypeByte            byte = 2
+	objTypeShort           byte = 3
+	objTypeInt             byte = 4
+	objTypeLong            byte = 5
+	objTypeFloat           byte = 6
+	objTypeDouble          byte = 7
+	objTypeChar            byte = 8
+	objTypeBoolean         byte = 9
+	objTypeString          byte = 10
+	objTypeNull            byte = 11
+	objTypeCompiledFunc    byte = 12
+	objTypeArray           byte = 13
+	objTypeHash            byte = 14
+)
+
+// serializeObject writes an object to the writer
+func serializeObject(w io.Writer, obj object.Object) error {
+	switch o := obj.(type) {
+	case *object.Integer:
+		if err := binary.Write(w, binary.BigEndian, objTypeInteger); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Byte:
+		if err := binary.Write(w, binary.BigEndian, objTypeByte); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Short:
+		if err := binary.Write(w, binary.BigEndian, objTypeShort); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Int:
+		if err := binary.Write(w, binary.BigEndian, objTypeInt); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Long:
+		if err := binary.Write(w, binary.BigEndian, objTypeLong); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Float:
+		if err := binary.Write(w, binary.BigEndian, objTypeFloat); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Double:
+		if err := binary.Write(w, binary.BigEndian, objTypeDouble); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Char:
+		if err := binary.Write(w, binary.BigEndian, objTypeChar); err != nil {
+			return err
+		}
+		return binary.Write(w, binary.BigEndian, o.Value)
+
+	case *object.Boolean:
+		if err := binary.Write(w, binary.BigEndian, objTypeBoolean); err != nil {
+			return err
+		}
+		var val byte
+		if o.Value {
+			val = 1
+		}
+		return binary.Write(w, binary.BigEndian, val)
+
+	case *object.String:
+		if err := binary.Write(w, binary.BigEndian, objTypeString); err != nil {
+			return err
+		}
+		// Write string length
+		strLen := uint32(len(o.Value))
+		if err := binary.Write(w, binary.BigEndian, strLen); err != nil {
+			return err
+		}
+		// Write string bytes
+		_, err := w.Write([]byte(o.Value))
+		return err
+
+	case *object.Null:
+		return binary.Write(w, binary.BigEndian, objTypeNull)
+
+	case *object.CompiledFunction:
+		if err := binary.Write(w, binary.BigEndian, objTypeCompiledFunc); err != nil {
+			return err
+		}
+		// Write instructions length
+		insLen := uint32(len(o.Instructions))
+		if err := binary.Write(w, binary.BigEndian, insLen); err != nil {
+			return err
+		}
+		// Write instructions
+		if _, err := w.Write(o.Instructions); err != nil {
+			return err
+		}
+		// Write NumLocals
+		if err := binary.Write(w, binary.BigEndian, uint32(o.NumLocals)); err != nil {
+			return err
+		}
+		// Write NumParameters
+		return binary.Write(w, binary.BigEndian, uint32(o.NumParameters))
+
+	case *object.Array:
+		if err := binary.Write(w, binary.BigEndian, objTypeArray); err != nil {
+			return err
+		}
+		// Write array length
+		arrLen := uint32(len(o.Elements))
+		if err := binary.Write(w, binary.BigEndian, arrLen); err != nil {
+			return err
+		}
+		// Write each element
+		for _, elem := range o.Elements {
+			if err := serializeObject(w, elem); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case *object.Hash:
+		if err := binary.Write(w, binary.BigEndian, objTypeHash); err != nil {
+			return err
+		}
+		// Write hash length
+		hashLen := uint32(len(o.Pairs))
+		if err := binary.Write(w, binary.BigEndian, hashLen); err != nil {
+			return err
+		}
+		// Write each key-value pair
+		for _, pair := range o.Pairs {
+			if err := serializeObject(w, pair.Key); err != nil {
+				return err
+			}
+			if err := serializeObject(w, pair.Value); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported object type for serialization: %s", obj.Type())
+	}
+}
+
+// deserializeObject reads an object from the reader
+func deserializeObject(r io.Reader) (object.Object, error) {
+	var objType byte
+	if err := binary.Read(r, binary.BigEndian, &objType); err != nil {
+		return nil, err
+	}
+
+	switch objType {
+	case objTypeInteger:
+		var value int64
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Integer{Value: value}, nil
+
+	case objTypeByte:
+		var value int8
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Byte{Value: value}, nil
+
+	case objTypeShort:
+		var value int16
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Short{Value: value}, nil
+
+	case objTypeInt:
+		var value int32
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Int{Value: value}, nil
+
+	case objTypeLong:
+		var value int64
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Long{Value: value}, nil
+
+	case objTypeFloat:
+		var value float32
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Float{Value: value}, nil
+
+	case objTypeDouble:
+		var value float64
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Double{Value: value}, nil
+
+	case objTypeChar:
+		var value rune
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Char{Value: value}, nil
+
+	case objTypeBoolean:
+		var value byte
+		if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+			return nil, err
+		}
+		return &object.Boolean{Value: value == 1}, nil
+
+	case objTypeString:
+		// Read string length
+		var strLen uint32
+		if err := binary.Read(r, binary.BigEndian, &strLen); err != nil {
+			return nil, err
+		}
+		// Read string bytes
+		strBytes := make([]byte, strLen)
+		if _, err := io.ReadFull(r, strBytes); err != nil {
+			return nil, err
+		}
+		return &object.String{Value: string(strBytes)}, nil
+
+	case objTypeNull:
+		return &object.Null{}, nil
+
+	case objTypeCompiledFunc:
+		// Read instructions length
+		var insLen uint32
+		if err := binary.Read(r, binary.BigEndian, &insLen); err != nil {
+			return nil, err
+		}
+		// Read instructions
+		instructions := make([]byte, insLen)
+		if _, err := io.ReadFull(r, instructions); err != nil {
+			return nil, err
+		}
+		// Read NumLocals
+		var numLocals uint32
+		if err := binary.Read(r, binary.BigEndian, &numLocals); err != nil {
+			return nil, err
+		}
+		// Read NumParameters
+		var numParameters uint32
+		if err := binary.Read(r, binary.BigEndian, &numParameters); err != nil {
+			return nil, err
+		}
+		return &object.CompiledFunction{
+			Instructions:  instructions,
+			NumLocals:     int(numLocals),
+			NumParameters: int(numParameters),
+		}, nil
+
+	case objTypeArray:
+		// Read array length
+		var arrLen uint32
+		if err := binary.Read(r, binary.BigEndian, &arrLen); err != nil {
+			return nil, err
+		}
+		// Read each element
+		elements := make([]object.Object, arrLen)
+		for i := uint32(0); i < arrLen; i++ {
+			elem, err := deserializeObject(r)
+			if err != nil {
+				return nil, err
+			}
+			elements[i] = elem
+		}
+		return &object.Array{Elements: elements}, nil
+
+	case objTypeHash:
+		// Read hash length
+		var hashLen uint32
+		if err := binary.Read(r, binary.BigEndian, &hashLen); err != nil {
+			return nil, err
+		}
+		// Read each key-value pair
+		pairs := make(map[object.HashKey]object.HashPair)
+		for i := uint32(0); i < hashLen; i++ {
+			key, err := deserializeObject(r)
+			if err != nil {
+				return nil, err
+			}
+			value, err := deserializeObject(r)
+			if err != nil {
+				return nil, err
+			}
+			// Get hash key
+			hashable, ok := key.(object.Hashable)
+			if !ok {
+				return nil, fmt.Errorf("key is not hashable: %s", key.Type())
+			}
+			pairs[hashable.HashKey()] = object.HashPair{Key: key, Value: value}
+		}
+		return &object.Hash{Pairs: pairs}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown object type in bytecode: %d", objType)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,23 +6,92 @@ import (
 	"bhasa/parser"
 	"bhasa/repl"
 	"bhasa/vm"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 func main() {
-	if len(os.Args) < 2 {
+	// Define CLI flags
+	compileMode := flag.Bool("c", false, "Compile source to bytecode")
+	outputFile := flag.String("o", "", "Output file for compiled bytecode")
+	showHelp := flag.Bool("h", false, "Show help message")
+	showVersion := flag.Bool("v", false, "Show version information")
+
+	flag.Parse()
+
+	// Show help
+	if *showHelp {
+		printHelp()
+		return
+	}
+
+	// Show version
+	if *showVersion {
+		fmt.Println("Bhasa (ভাষা) Programming Language v1.0.0")
+		fmt.Println("Bytecode Compiler & VM")
+		return
+	}
+
+	// Get remaining arguments (non-flag arguments)
+	args := flag.Args()
+
+	if len(args) < 1 {
 		// Start REPL if no file is provided
 		repl.Start(os.Stdin, os.Stdout)
 		return
 	}
 
-	// Run file
-	filename := os.Args[1]
-	runFile(filename)
+	filename := args[0]
+
+	// Check if file is bytecode or source
+	if isBytecodeFile(filename) {
+		// Execute pre-compiled bytecode
+		runBytecode(filename)
+	} else if *compileMode {
+		// Compile source to bytecode
+		compileFile(filename, *outputFile)
+	} else {
+		// Run source file directly
+		runFile(filename)
+	}
 }
 
+func printHelp() {
+	fmt.Println("Bhasa (ভাষা) Programming Language - Usage:")
+	fmt.Println()
+	fmt.Println("  bhasa                         Start REPL (interactive mode)")
+	fmt.Println("  bhasa <file>                  Run source file (.bhasa or .ভাষা)")
+	fmt.Println("  bhasa <bytecode>              Execute bytecode file (.compiled or .সংকলিত)")
+	fmt.Println("  bhasa -c <file>               Compile source to bytecode")
+	fmt.Println("  bhasa -c -o <output> <file>   Compile with custom output name")
+	fmt.Println("  bhasa -h                      Show this help message")
+	fmt.Println("  bhasa -v                      Show version information")
+	fmt.Println()
+	fmt.Println("File Extensions:")
+	fmt.Println("  Source:    .bhasa or .ভাষা")
+	fmt.Println("  Bytecode:  .compiled or .সংকলিত")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  bhasa program.bhasa                   # Run source file")
+	fmt.Println("  bhasa -c program.bhasa                # Compile to program.compiled")
+	fmt.Println("  bhasa -c -o output.compiled program.bhasa")
+	fmt.Println("  bhasa -c -o output.সংকলিত program.ভাষা   # Bengali extensions")
+	fmt.Println("  bhasa program.compiled                # Execute compiled bytecode")
+	fmt.Println()
+	fmt.Println("Note: Flags must appear before the filename argument")
+}
+
+// isBytecodeFile checks if the file is a bytecode file based on extension
+func isBytecodeFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".compiled" || ext == ".সংকলিত"
+}
+
+// runFile compiles and runs a source file
 func runFile(filename string) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -50,6 +119,88 @@ func runFile(filename string) {
 	}
 
 	machine := vm.New(comp.Bytecode())
+	err = machine.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Executing bytecode failed:\n %s\n", err)
+		os.Exit(1)
+	}
+}
+
+// compileFile compiles a source file to bytecode
+func compileFile(filename string, outputFile string) {
+	// Read source file
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse source
+	l := lexer.New(string(content))
+	p := parser.New(l)
+
+	program := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		fmt.Fprintln(os.Stderr, "Parser errors:")
+		for _, msg := range p.Errors() {
+			fmt.Fprintf(os.Stderr, "\t%s\n", msg)
+		}
+		os.Exit(1)
+	}
+
+	// Compile to bytecode
+	comp := compiler.New()
+	err = comp.Compile(program)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Compilation failed:\n %s\n", err)
+		os.Exit(1)
+	}
+
+	// Determine output filename
+	if outputFile == "" {
+		// Default: replace extension with .compiled
+		ext := filepath.Ext(filename)
+		outputFile = strings.TrimSuffix(filename, ext) + ".compiled"
+	}
+
+	// Create output file
+	file, err := os.Create(outputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	// Serialize bytecode to file
+	bytecode := comp.Bytecode()
+	err = bytecode.Serialize(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error serializing bytecode: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully compiled %s to %s\n", filename, outputFile)
+}
+
+// runBytecode executes a pre-compiled bytecode file
+func runBytecode(filename string) {
+	// Open bytecode file
+	file, err := os.Open(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening bytecode file: %v\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	// Deserialize bytecode
+	bytecode, err := compiler.Deserialize(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error deserializing bytecode: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Execute bytecode in VM
+	machine := vm.New(bytecode)
 	err = machine.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Executing bytecode failed:\n %s\n", err)


### PR DESCRIPTION
Implemented bytecode compilation and execution similar to Python's .pyc files:

Features:
- Serialize compiled bytecode to disk (.compiled or .সংকলিত extensions)
- Deserialize and execute pre-compiled bytecode
- Binary format with magic number (0x42484153) and version tracking
- Support for all Bhasa object types in constants pool
- CLI flags: -c for compilation, -o for custom output filename

Benefits:
- Faster startup time (skip lexing/parsing/compilation)
- Bytecode distribution without source code
- Separate compilation and execution phases

Usage:
  bhasa -c program.bhasa                    # Compile to program.compiled
  bhasa -c -o output.compiled program.bhasa # Custom output name
  bhasa -c -o output.সংকলিত program.ভাষা      # Bengali extensions
  bhasa program.compiled                    # Execute bytecode

Implementation:
- compiler/serializer.go: Binary serialization/deserialization
- main.go: CLI flags and compilation/execution modes
- .gitignore: Exclude compiled bytecode files

Tested with multiple programs including hello world, fibonacci, and arrays.